### PR TITLE
Add types to make the code more robust

### DIFF
--- a/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
+++ b/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
@@ -60,18 +60,18 @@ export class DynamicFormComponent implements OnInit {
     /**
      * Iterate through fields for each section
      */
-    this.fieldset.forEach(field => {
+    this.fieldset.forEach((field, fieldIndex) => {
       /**
        * Create each form field and add it to the Form Group
        */
-      this.form.addControl(field.name, this.initializeFormControl(field));
+      this.form.addControl(field.name, this.initializeFormControl(field, fieldIndex));
 
       /**
        * Add Slide Toggle child fields if needed
        */
       if (field.children) {
         field.children.forEach(child => {
-          this.form.addControl(child.name, this.initializeFormControl(child));
+          this.form.addControl(child.name, this.initializeFormControl(child, -1));
         });
         this.togglesWithChildren.push(
           { name: field.name, value: field.defaultValue, children: field.children });
@@ -97,7 +97,7 @@ export class DynamicFormComponent implements OnInit {
     this.formReady = true;
   }
 
-  initializeFormControl(field): UntypedFormControl {
+  initializeFormControl(field: Field, parentIndex: number): UntypedFormControl {
     let value;
 
     /**
@@ -112,13 +112,16 @@ export class DynamicFormComponent implements OnInit {
      * push specific false toggles to falseToggles array
      */
     if (field.type === FieldType.SLIDETOGGLE) {
+      if (parentIndex < 0) {
+        throw new Error('Nested slide toggles are not supported');
+      }
 
       if (typeof value === 'undefined') {
         value = true;
       }
 
       if (field.defaultValue === false) {
-        this.hideChildren(field);
+        this.hideChildren(parentIndex);
       }
     }
 
@@ -155,7 +158,7 @@ export class DynamicFormComponent implements OnInit {
     });
   }
 
-  toggleChildren(name, toggleValue): void {
+  toggleChildren(name: string, toggleValue: boolean): void {
     const parentIndex = this.fieldset.findIndex(field => field.name === name);
 
     if (toggleValue) {
@@ -178,7 +181,7 @@ export class DynamicFormComponent implements OnInit {
     }
   }
 
-  showChildren(parentIndex): void {
+  showChildren(parentIndex: number): void {
     const parent = { ...this.fieldset[parentIndex] };
 
     if (!parent.children) {

--- a/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
+++ b/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Field, FieldType, KeyValuePair } from '../models/dynamic-reactive-form.model';
 import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { NgxErrorsModule } from '@ngspot/ngx-errors';
@@ -11,6 +12,7 @@ import { DynamicFormFieldComponent } from '../dynamic-form-field/dynamic-form-fi
   styleUrls: ['./dynamic-form.component.css']
 })
 export class DynamicFormComponent implements OnInit {
+  readonly #destroyRef = inject(DestroyRef);
 
   protected readonly formBuilder = inject(UntypedFormBuilder);
 
@@ -152,9 +154,11 @@ export class DynamicFormComponent implements OnInit {
      * Set up valueChanges subscription for each Slide Toggle field w/ children
      */
     this.togglesWithChildren.forEach(parent => {
-      this.form.controls[parent.name].valueChanges.subscribe(value => {
-        this.toggleChildren(parent.name, value);
-      });
+      this.form.controls[parent.name].valueChanges
+        .pipe(takeUntilDestroyed(this.#destroyRef))
+        .subscribe(value => {
+          this.toggleChildren(parent.name, value);
+        });
     });
   }
 

--- a/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
+++ b/projects/dynamic-reactive-form/src/lib/dynamic-form/dynamic-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
-import { Field, KeyValuePair } from '../models/dynamic-reactive-form.model';
+import { Field, FieldType, KeyValuePair } from '../models/dynamic-reactive-form.model';
 import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { NgxErrorsModule } from '@ngspot/ngx-errors';
 import { DynamicFormFieldComponent } from '../dynamic-form-field/dynamic-form-field.component';
@@ -111,7 +111,7 @@ export class DynamicFormComponent implements OnInit {
      * Default Slide Toggles to true unless otherwise specified,
      * push specific false toggles to falseToggles array
      */
-    if (field.type === 5) {
+    if (field.type === FieldType.SLIDETOGGLE) {
 
       if (typeof value === 'undefined') {
         value = true;

--- a/projects/dynamic-reactive-form/src/lib/models/dynamic-reactive-form.model.ts
+++ b/projects/dynamic-reactive-form/src/lib/models/dynamic-reactive-form.model.ts
@@ -1,4 +1,4 @@
-import { Validators } from '@angular/forms';
+import { ValidatorFn, Validators } from '@angular/forms';
 
 export enum FieldType {
     CHECKBOX,
@@ -21,7 +21,7 @@ export interface Field {
     disabled?: boolean;
     options?: string[];
     parent?: string;
-    validation?: Validators[];
+    validation?: ValidatorFn[];
     visible?: boolean;
 }
 

--- a/projects/dynamic-reactive-form/tsconfig.lib.json
+++ b/projects/dynamic-reactive-form/tsconfig.lib.json
@@ -1,6 +1,6 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/lib",
     "declaration": true,


### PR DESCRIPTION
Let TypeScript help us to pass around the right arguments to our functions.

Not handled yet: the `Error` type in `dynamic-reactive-form.model.ts`

For me it's not yet clear how this should work together with `ngxErrors` and `ngxError`. My guess is, that `Validtors[]` is not the right type for that. Someone with more knowledge about `@ngspot/ngx-errors` should take a look at that.